### PR TITLE
fix: corrije o nome do arquivo .c no arquivo .toml

### DIFF
--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,4 +1,4 @@
 [wokwi]
 version = 1
-firmware = 'build/serial.uf2'
-elf = 'build/serial.elf'
+firmware = 'build/comunicacao-serial.uf2'
+elf = 'build/comunicacao-serial.elf'


### PR DESCRIPTION
**No arquivo .toml** o nome do arquivo .c estava como `serial` o que foi devidamente corrijido para o seu nome de fato.